### PR TITLE
docs(subprocess): Fixed a bug in the Deno.run arguments

### DIFF
--- a/examples/subprocess.md
+++ b/examples/subprocess.md
@@ -26,7 +26,7 @@ This example is the equivalent of running `'echo hello'` from the command line.
 const command = ["echo", "hello"];
 
 // create subprocess
-const p = Deno.run({ cmd : command });
+const p = Deno.run({ cmd: command });
 
 // await its completion
 await p.status();

--- a/examples/subprocess.md
+++ b/examples/subprocess.md
@@ -23,10 +23,10 @@ This example is the equivalent of running `'echo hello'` from the command line.
  */
 
 // define command used to create the subprocess
-const cmd = ["echo", "hello"];
+const command = ["echo", "hello"];
 
 // create subprocess
-const p = Deno.run({ cmd });
+const p = Deno.run({ cmd : command });
 
 // await its completion
 await p.status();


### PR DESCRIPTION
The sample code wouldn't run since the argument requires the key cmd to specify the actual command.